### PR TITLE
[BUGFIX] fixes link of bookmark/shortcut button in backend module

### DIFF
--- a/Classes/Controller/BackendLayoutController.php
+++ b/Classes/Controller/BackendLayoutController.php
@@ -1082,6 +1082,7 @@ class BackendLayoutController extends \TYPO3\CMS\Backend\Module\BaseScriptClass
             ->setGetVariables(
                 [
                     'id',
+                    'M',
                     'edit_record',
                     'pointer',
                     'new_unique_uid',


### PR DESCRIPTION
This bugfix fixes the link-generation of the star-shaped bookmark/shortcut button on each page in the TemplavoilaPlus page-module.